### PR TITLE
fixed participant linkage when uploading session

### DIFF
--- a/bicycledata/routes.py
+++ b/bicycledata/routes.py
@@ -231,7 +231,7 @@ def api_v2_session_upload_chunk():
                 file.write(data)
 
         # Update the session list in user data
-        config = read_v2_config_file(ident, file_path=os.path.join(file_path, 'config.json'))
+        config = read_v2_config_file(ident, file_path=os.path.join(file_path, 'bicycleinit.json'))
         if config:
             participants = json.loads(config).get("participants", [])
             for participant in participants:

--- a/bicycledata/routes.py
+++ b/bicycledata/routes.py
@@ -211,15 +211,7 @@ def api_v2_session_upload_chunk():
         file_path = os.path.join("data", "v2", "devices", ident, "sessions", session)
         os.makedirs(file_path, exist_ok=True)
 
-        # Update the session list in user data
-        config = read_v2_config_file(ident)
-        participants = json.loads(config).get("participants", [])
-        for participant in participants:
-            udata = load_user_by_id(participant)
-            session_entry = f"{ident}/{session}"
-            if session_entry not in udata["sessions"]:
-                udata["sessions"].append(session_entry)
-                save_user(udata)
+
 
         # Append log to data/devices/<ident>/sessions/<session>/bicycleinit.log
         log_path = os.path.join(file_path, filename)
@@ -240,6 +232,17 @@ def api_v2_session_upload_chunk():
             with open(log_path, "a", encoding="utf-8") as file:
                 file.write(data)
 
+        # Update the session list in user data
+        config = read_v2_config_file(ident, file_path=os.path.join(file_path, 'config.json'))
+        if config:
+            participants = json.loads(config).get("participants", [])
+            for participant in participants:
+                udata = load_user_by_id(participant)
+                session_entry = f"{ident}/{session}"
+                if session_entry not in udata["sessions"]:
+                    udata["sessions"].append(session_entry)
+                    save_user(udata)
+        
         ping_v2(ident, "/api/v2/session/upload")
         return jsonify({"status": "ok"}), 200
     except Exception as e:

--- a/bicycledata/routes.py
+++ b/bicycledata/routes.py
@@ -211,8 +211,6 @@ def api_v2_session_upload_chunk():
         file_path = os.path.join("data", "v2", "devices", ident, "sessions", session)
         os.makedirs(file_path, exist_ok=True)
 
-
-
         # Append log to data/devices/<ident>/sessions/<session>/bicycleinit.log
         log_path = os.path.join(file_path, filename)
         # Support optional encoding/mimetype in payload (e.g., base64-encoded PNG)


### PR DESCRIPTION
## Description
Fixes participant linkage timing in session uploads. The participant session list update now occurs after all session data has been written, preventing race conditions where participants could be linked to incomplete sessions. Also adds explicit config file path and null-check for safer config handling.

## Changes
- Moved participant linkage code from the start to the end of `api_v2_session_upload_chunk()`
- Added explicit config file path parameter: `file_path=os.path.join(file_path, 'bicycleinit.json')`
- Added null-check before processing config to handle missing files gracefully

## Why
This ensures participants are only linked to sessions after all data has been successfully written, preventing potential issues with incomplete uploads.


_Description generated by Claude Haiku 4.5_