### PR TITLE
Prevent crash when email is not configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.env/
+/venv/
 __pycache__/
 /wsgi.log
 /wsgi.sock
 /data/
 /bicycledata/static/files/*.img
+/pyrightconfig.json

--- a/bicycledata/email.py
+++ b/bicycledata/email.py
@@ -7,6 +7,9 @@ def send_email(to, subject, body, config):
     smtp_port = config.get("smtp-port")
     smtp_from = config.get("smtp-from")
 
+    if smtp_host is None or smtp_port is None or smtp_from is None:
+        return {"success": False, "error": "Email not configured"}
+
     # Build message
     msg = EmailMessage()
     msg["Subject"] = subject

--- a/bicycledata/user.py
+++ b/bicycledata/user.py
@@ -92,8 +92,6 @@ def load_user_by_id(user_id):
 
 
 def add_new_user(name, email):
-    DIR = os.path.join("data", "login")
-
     users = load_users()
 
     # check if any user already has this email


### PR DESCRIPTION
We typically don't configure a mail server in the development environment. This change prevents the application from crashing when attempting to send emails, e.g. for example when creating a new user.