### PR TITLE
Fix banner flex layout when displaying GPS track map

### DIFF
--- a/bicycledata/templates/devices_v2_ident_session.html
+++ b/bicycledata/templates/devices_v2_ident_session.html
@@ -59,7 +59,9 @@
 
   </div>
   {% if gps_track and gps_track|length > 1 %}
-  <div id="map" style="height: 400px; width: 100%; margin-bottom: 1em;"></div>
+  <span class="image object">
+    <div id="map" style="height: 400px; width: 100%;"></div>
+  </span>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script>


### PR DESCRIPTION
When a GPS track existed, the map `<div>` was rendered directly inside the flex container, and unlike the device image path, the map was not wrapped in the expected `.image.object` container, causing the flex layout to break.